### PR TITLE
Feature/burn

### DIFF
--- a/src/app/restake/fund/page.tsx
+++ b/src/app/restake/fund/page.tsx
@@ -129,7 +129,7 @@ export default function Staking() {
 
   const restake_deposit = async (event: { preventDefault: () => void; }) => {
     event.preventDefault();
-    // transfer(event);
+    transfer(event);
     const toastId = toast.loading("restaking...");
     console.log("restake", amount, "exchange", exchange)
     const amountAsNumber = parseFloat(amount);

--- a/src/app/restake/fund/page.tsx
+++ b/src/app/restake/fund/page.tsx
@@ -151,7 +151,7 @@ export default function Staking() {
       toast.dismiss(toastId);
     }
   };
-  
+
   const burnrestake = async (event: { preventDefault: () => void; }) => {
     event.preventDefault();
     const toastId = toast.loading("buring...");
@@ -170,7 +170,7 @@ export default function Staking() {
   const withdraw_restaked = async (event: { preventDefault: () => void; }) => {
     event.preventDefault();
 
-    transferRestake(event);
+   await  transferRestake(event);
     const toastId = toast.loading("Withdrawing...");
     console.log("withdraw", amount, "exchange", exchange)
     const tx = await sendTransaction(
@@ -185,7 +185,7 @@ export default function Staking() {
         console.log("Withdraw Failed", err);
         toast.dismiss(toastId);
       });
-     burnrestake(event);
+    await burnrestake(event);
   };
 
   return (

--- a/src/app/restake/fund/page.tsx
+++ b/src/app/restake/fund/page.tsx
@@ -143,7 +143,7 @@ export default function Staking() {
       )
 
       toast.dismiss(toastId);
-      toast.success(`Staked ${amount} NIBI successfully`);
+      toast.success(`Staked ${amount} stNIBI successfully`);
       console.log("restake tx", tx)
     }
     catch (error) {
@@ -162,8 +162,7 @@ export default function Staking() {
     )
       .then((res) => {
         toast.dismiss(toastId);
-        toast.success(`Unstaked ${withdrawAmount} NIBI successfully`);
-        console.log("unstake sendFrom tx", tx)
+        toast.success(`Unstaked ${withdrawAmount} stNIBI successfully`);
       }
       )
   }
@@ -180,13 +179,13 @@ export default function Staking() {
     )
       .then((res) => {
         toast.dismiss(toastId);
-        toast.success(`Withdraw ${amount} NIBI successfully`);
+        toast.success(`Withdraw ${amount} stNIBI successfully`);
       })
       .catch((err) => {
         console.log("Withdraw Failed", err);
         toast.dismiss(toastId);
       });
-    // await burnrestake(event);
+    await burnrestake(event);
   };
 
   return (
@@ -329,7 +328,7 @@ export default function Staking() {
                       <label className="form-control w-full">
                         <div className="input input-lg input-bordered">
                           <div className="flex align-middle justify-between text-center pt-2 ">
-                            {withdrawAmount} stNIBI
+                            {unstakedAmount} stNIBI
                           </div>
                         </div>
                       </label>

--- a/src/app/restake/fund/page.tsx
+++ b/src/app/restake/fund/page.tsx
@@ -81,7 +81,7 @@ export default function Staking() {
     const multipliedAmount = amountAsNumber * Math.pow(10, 6);
 
     const toastId = toast.loading("Transferring...");
-
+    console.log("multipliedAmount", multipliedAmount)
     console.log("transfering", stNIBITOKEN_CONTRACT_ADDRESS, "withdrawAmount", withdrawAmount, "amount", amount, "multipliedAmount", multipliedAmount)
     const tx = await sendTransaction(
       stNIBITOKEN_CONTRACT_ADDRESS,
@@ -93,7 +93,7 @@ export default function Staking() {
       .then((res) => {
         toast.dismiss(toastId);
         toast.success("Transferred Successfuly");
-        console.log("transfer tx", tx);
+        console.log("transfer tx");
       })
       .catch((err) => {
         console.log("Transfer Failed", err);
@@ -129,7 +129,7 @@ export default function Staking() {
 
   const restake_deposit = async (event: { preventDefault: () => void; }) => {
     event.preventDefault();
-    transfer(event);
+   await  transfer(event);
     const toastId = toast.loading("restaking...");
     console.log("restake", amount, "exchange", exchange)
     const amountAsNumber = parseFloat(amount);
@@ -151,7 +151,7 @@ export default function Staking() {
       toast.dismiss(toastId);
     }
   };
-
+  
   const burnrestake = async (event: { preventDefault: () => void; }) => {
     event.preventDefault();
     const toastId = toast.loading("buring...");
@@ -185,7 +185,7 @@ export default function Staking() {
         console.log("Withdraw Failed", err);
         toast.dismiss(toastId);
       });
-    await burnrestake(event);
+     burnrestake(event);
   };
 
   return (

--- a/src/app/stake/page.tsx
+++ b/src/app/stake/page.tsx
@@ -66,7 +66,7 @@ export default function Staking() {
 
 
   }
-
+  
   const getQueryDataFromContract = async () => {
     // if (address) {
     console.log("address", address)
@@ -131,7 +131,7 @@ export default function Staking() {
 
   const unstake = async (event: { preventDefault: () => void; }) => {
     event.preventDefault();
-    transfer(event);
+   await  transfer(event);
     const toastId = toast.loading("unstaking...");
     const amountAsNumber = parseFloat(unstakeAmount);
     const multipliedAmount = amountAsNumber * Math.pow(10, 6);


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to refactor stake and restake functions in the `Staking` component to include `await` before the `transfer` and `transferRestake` functions for proper asynchronous handling.

### Detailed summary
- Added `await` before `transfer` function calls in `unstake` and `restake_deposit` functions
- Updated success messages to reflect stNIBI instead of NIBI
- Added `await` before `burnrestake` function call in `withdraw_restaked` function
- Renamed `withdrawAmount` variable to `unstakedAmount` in the UI display

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->